### PR TITLE
Custom rules and empty content

### DIFF
--- a/demo/js/models/user.js
+++ b/demo/js/models/user.js
@@ -15,7 +15,10 @@ App.User = DS.Model.extend(Ember.Validation.ValidatorSupport, {
       }
     }).message("You have to be %@2 to join");
 
-    this.property("zodiac").minLength(4);
+    this.property("zodiac").custom(function(value) {
+      console.log('Checking zodiac', value);
+      return !Ember.isEmpty(value);
+    }).message('Zodiac must be set. Note that this field does not revalidate when you empty it.');
 
     this.property("password")
       .required()

--- a/src/valueValidator.js
+++ b/src/valueValidator.js
@@ -38,7 +38,7 @@ Ember.Validation.ValueValidator = Ember.Object.extend({
 
     for (var i=0; i<rules.length; i++) {
       var result = rules[i]._validate(value, obj);
-      if(!result.isValid  || result.override) {
+      if(!result.isValid) {
         if(!result.isValid) {
           vresult.setError(result.error);
         }


### PR DESCRIPTION
Sorry - this isn't a pull request but I wanted to include some code to illustrate the problem I'm having....

As you can see in 9de723377f230c3, something weird happens with custom rules in the case of empty content. The commit message has more details of the exact problem. In 42c55777ecdd I found that the problem seems to be somehow related to the `result.override` property but the change in that commit is not meant to be a fix as I'm sure it breaks other stuff!

Do you know what is going wrong here?
