### PR TITLE
Feature request: enable validation rules to be toggled based on the status of another field

### DIFF
--- a/demo/js/models/user.js
+++ b/demo/js/models/user.js
@@ -30,6 +30,7 @@ App.User = DS.Model.extend(Ember.Validation.ValidatorSupport, {
 
     this.property("secretNinjaWord", "Secret ninja word")
       .required(function(value) {
+        console.log('Is secretNinjaWord required?', this.get('isNinja'));
         return this.get('isNinja');
       })
       .custom(function(value) {

--- a/demo/js/models/user.js
+++ b/demo/js/models/user.js
@@ -27,6 +27,14 @@ App.User = DS.Model.extend(Ember.Validation.ValidatorSupport, {
         return this.get('password2')
       })
       .message("Passwords must be equal");
+
+    this.property("secretNinjaWord", "Secret ninja word")
+      .required(function(value) {
+        return this.get('isNinja');
+      })
+      .custom(function(value) {
+        return !this.get('isNinja') || value === 'NINJA!';
+      }).message('The secret ninja word must be "NINJA!"');
   }),
 
   name: DS.attr('string'),
@@ -34,5 +42,7 @@ App.User = DS.Model.extend(Ember.Validation.ValidatorSupport, {
   age: DS.attr('number'),
   zodiac: DS.attr('string'),
   password: DS.attr('string'),
-  password2: DS.attr('string')
+  password2: DS.attr('string'),
+  isNinja: DS.attr('boolean'),
+  secretNinjaWord: DS.attr('string')
 });

--- a/demo/templates/example2.hbs
+++ b/demo/templates/example2.hbs
@@ -60,6 +60,21 @@
         </div>
     </div>
     <div class="control-group">
+        <label class="control-label" for="inputIsAdmin">Is ninja?</label>
+        <div class="controls">
+            {{input type="checkbox" id="inputIsAdmin" checked=isNinja}}
+        </div>
+    </div>
+    {{#if isNinja}}
+    <div class="control-group" {{bind-attr class="view.inputSecretWord.validationResult.hasError:error:"}}>
+        <label class="control-label" for="inputSecretWord">Secret Ninja Word</label>
+        <div class="controls">
+            {{validator-text-field viewName="inputSecretWord" id="inputSecretWord" value=secretNinjaWord}}
+            <span class="help-inline">{{view.inputSecretWord.validationResult.error}}</span>
+        </div>
+    </div>
+    {{/if}}
+    <div class="control-group">
         <div class="controls">
             <button type="submit" class="btn" {{action "clear"}}>Clear</button>
             <button type="submit" class="btn" {{action "validate"}}>Validate</button>

--- a/src/chaining.js
+++ b/src/chaining.js
@@ -23,9 +23,15 @@ Ember.Validation.Chaining = Ember.Object.extend({
    * sets the property as required
    *
    * @method required
+   * @param {boolean} isRequired Whether or not this field is required. If a function is passed in then it 
+   * will be run every time the field is validated (which allows it to be dependant on other properties of
+   * the object)
    */
-  required: function() {
-    set(this, 'isRequired', true);
+  required: function(isRequired) {
+    if (Ember.isNone(isRequired)) {
+      isRequired = true;
+    }
+    set(this, 'isRequired', isRequired);
     return this;
   },
 
@@ -42,7 +48,11 @@ Ember.Validation.Chaining = Ember.Object.extend({
       v.message = msg;
     } else {
       // if there is no validator, check if required has been set
-      if(get(this, 'isRequired')){
+      var isRequired = get(this, 'isRequired');
+      if (Ember.Validation.toType(isRequired) === 'function') {
+        isRequired = isRequired();
+      }
+      if(isRequired){
         // required is the last validator
         set(this, 'requiredErrorMessage', msg);
       } else {
@@ -66,10 +76,16 @@ Ember.Validation.Chaining = Ember.Object.extend({
     var propertyName = get(this, 'propertyName');
     var message = get(this, 'errorMessage');
     var requiredMessage = get(this, 'requiredErrorMessage');
+    var isRequired = get(this, 'isRequired');
+    if (Ember.Validation.toType(isRequired) === 'function') {
+      isRequired = isRequired;
+    } else {
+      isRequired = !!isRequired;
+    }
 
     var req = Ember.Validation.RequiredRule.create({
       propertyName:propertyName,
-      parameters:[!!get(this, 'isRequired')]
+      parameters:[isRequired]
     });
 
     if(toType(requiredMessage) === 'string') {

--- a/tests/rules.js
+++ b/tests/rules.js
@@ -21,6 +21,8 @@
   test('RequiredRule', function() {
     var rule1 = Ember.Validation.RequiredRule.create({parameters:[false]});
     var rule2 = Ember.Validation.RequiredRule.create({parameters:[true]});
+    var rule3 = Ember.Validation.RequiredRule.create({parameters:[function() { return false; }]});
+    var rule4 = Ember.Validation.RequiredRule.create({parameters:[function() { return true; }]});
 
     var result1 = rule1._validate("");
     var result2 = rule1._validate("test");
@@ -38,6 +40,23 @@
     strictEqual(result3.error, "(null) is required", "required: \"\" - error");
     strictEqual(result4.isValid, true, "required: test - isValid");
     strictEqual(result4.override, false, "required: test - override");
+
+    var result5 = rule3._validate("");
+    var result6 = rule3._validate("test");
+
+    strictEqual(result5.isValid, true, "not required (func) \"\" - isValid");
+    strictEqual(result5.override, true, "not required (func): \"\" - override");
+    strictEqual(result6.isValid, true, "not required (func): test - isValid");
+    strictEqual(result6.override, false, "not required (func): test - override");
+
+    var result7 = rule4._validate("");
+    var result8 = rule4._validate("test");
+
+    strictEqual(result7.isValid, false, "required (func) \"\" - isValid");
+    strictEqual(result7.override, false, "required (func): \"\" - override");
+    strictEqual(result7.error, "(null) is required", "required (func): \"\" - error");
+    strictEqual(result8.isValid, true, "required (func): test - isValid");
+    strictEqual(result8.override, false, "required (func): test - override");
 
   });
 


### PR DESCRIPTION
Again, this isn't a pull request but a feature request including some code showing the issue I'm trying to solve.

In my app I have a payment model and payment can be of different sorts (e.g. cash, credit card, bank transfer etc). In the case where it is credit card I show additional fields and need to validate them as required and with a custom rule (to check the credit card number and expiry date etc).

In 08aba56 I have added a contrived version of this setup to your example. The commit message describes a way that this setup is broken currently.

More generally I'd like to make a feature request for some sort of "guard" which could be applied to the start of a chain. Then I could put the guard at the front of the `secretNinjaWord` chain and wouldn't need to check the value of `isNinja` in every rule after that but the rules would be applied and removed when the value of `isNinja` changed. Does this make sense?
