### PR TITLE
Using `Ember.isEmpty` rather than a custom `isEmpty` method.

### DIFF
--- a/src/rules/misc.js
+++ b/src/rules/misc.js
@@ -4,16 +4,12 @@ Ember.Validation.RequiredRule = Ember.Validation.BaseRule.extend({
 
   message: msgs.required,
 
-  isEmpty: function(value) {
-    return value === null || value === '';
-  },
-
   validate: function(value, required) {
-    return this.isEmpty(value) ? !required : true;
+    return Ember.isEmpty(value) ? !required : true;
   },
 
   override: function(value, isValid, required) {
-    return this.isEmpty(value) && !required;
+    return Ember.isEmpty(value) && !required;
   }
 });
 


### PR DESCRIPTION
I was running into problems with the required rule not being applied
when a model was validated before you had visited all of the fields.

These turned out to be because of undefined values. `Ember.isEmpty`
catches `undefined` as well as `null` and `''` (and also an empty
array but I think that's OK?)
