### PR TITLE
Should support specifying a base class with ValidatorSupport mixin

### DIFF
--- a/src/mixins/validator_support.js
+++ b/src/mixins/validator_support.js
@@ -39,7 +39,9 @@ Ember.Validation.ValidatorSupport = Ember.Mixin.create(Ember.Evented, {
       }
     }
 
-    this.set('validationResult', validator.createResult());
+    if (validator) {
+      this.set('validationResult', validator.createResult());
+    }
   },
 
   /**

--- a/tests/mixins.js
+++ b/tests/mixins.js
@@ -40,6 +40,21 @@
 
   });
 
+  /**
+   * Should support specifying a base class without explicitly declaring a validator property
+   * 
+   * Example:
+   * App.Form = Em.Object.extend(Ember.Validation.ValidatorSupport);
+   * App.Form.create();
+   */
+  test('ValidatorSupport initializes without explicitly declaring validator property', function() {
+    expect(1);
+    
+    var o = Ember.Object.extend(Ember.Validation.ValidatorSupport).create();
+    
+    ok(o); 
+  });
+
   test('ValidatorSupport callbacks', function() {
     expect(5);
 


### PR DESCRIPTION
Should support specifying a base class without explicitly declaring a validator property

Example:
App.Form = Em.Object.extend(Ember.Validation.ValidatorSupport);
App.Form.create();
